### PR TITLE
Allow returning *only* SNP ids from SNPRateFreq

### DIFF
--- a/R/AllUtilities.R
+++ b/R/AllUtilities.R
@@ -177,11 +177,13 @@ snpgdsClose <- function(gdsobj)
 #
 
 snpgdsSNPRateFreq <- function(gdsobj, sample.id=NULL, snp.id=NULL,
-    with.id=FALSE)
+    with.id=FALSE, with.snp.id=FALSE, with.sample.id=FALSE)
 {
     # check
     ws <- .InitFile(gdsobj, sample.id=sample.id, snp.id=snp.id)
     stopifnot(is.logical(with.id))
+    stopifnot(is.logical(with.snp.id))
+    stopifnot(is.logical(with.sample.id))
 
     # call allele freq. and missing rates
     rv <- .Call(gnrSNPRateFreq)
@@ -189,10 +191,17 @@ snpgdsSNPRateFreq <- function(gdsobj, sample.id=NULL, snp.id=NULL,
 
     if (with.id)
     {
+        with.snp.id <- TRUE
+        with.sample.id <- TRUE
+    }
+    if (with.sample.id)
+    {
         rv$sample.id <- read.gdsn(index.gdsn(gdsobj, "sample.id"))
         if (!is.null(ws$samp.flag))
             rv$sample.id <- rv$sample.id[ws$samp.flag]
-
+    }
+    if (with.snp.id)
+    {
         rv$snp.id <- read.gdsn(index.gdsn(gdsobj, "snp.id"))
         if (!is.null(ws$snp.flag))
             rv$snp.id <- rv$snp.id[ws$snp.flag]

--- a/man/snpgdsSNPRateFreq.Rd
+++ b/man/snpgdsSNPRateFreq.Rd
@@ -8,7 +8,7 @@
 per SNP.
 }
 \usage{
-snpgdsSNPRateFreq(gdsobj, sample.id=NULL, snp.id=NULL, with.id=FALSE)
+snpgdsSNPRateFreq(gdsobj, sample.id=NULL, snp.id=NULL, with.id=FALSE, with.sample.id=FALSE, with.snp.id=FALSE)
 }
 \arguments{
     \item{gdsobj}{an object of class \code{\link{SNPGDSFileClass}},
@@ -18,14 +18,16 @@ snpgdsSNPRateFreq(gdsobj, sample.id=NULL, snp.id=NULL, with.id=FALSE)
     \item{snp.id}{a vector of snp id specifying selected SNPs;
         if \code{NULL}, all SNPs will be used}
     \item{with.id}{if \code{TRUE}, return sample and SNP IDs}
+    \item{with.snp.id}{if \code{TRUE}, return only SNP IDs}
+    \item{with.sample.id}{if \code{TRUE}, return only sample IDs}
 }
 \value{
     Return a list:
     \item{AlleleFreq}{allele frequencies}
     \item{MinorFreq}{minor allele frequencies}
     \item{MissingRate}{missing rates}
-    \item{sample.id}{sample id, if \code{with.id=TRUE}}
-    \item{snp.id}{SNP id, if \code{with.id=TRUE}}
+    \item{sample.id}{sample id, if \code{with.id=TRUE} or \code{with.sample.id=TRUE}}
+    \item{snp.id}{SNP id, if \code{with.id=TRUE} or \code{with.snp.id=TRUE}}
 }
 \author{Xiuwen Zheng}
 \seealso{


### PR DESCRIPTION
This patch allows one to receive only the SNP ids when calling `snpgdsSNPRateFreq`. This is primarily useful because then the return value can easily be converted into a data frame, as all members of the list will have the same length.